### PR TITLE
feat: added support for RISC Zero

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -117,20 +117,36 @@
 # They are passed as environment variables to Contemplants created on Vast.ai.
 # Note: MAGISTER_DROP_ENDPOINT and HIEROPHANT_WS_ADDRESS are managed automatically.
 
-# Prover type: "cpu" or "cuda" (default: "cpu").
-# CPU proving is slower but doesn't require GPU-specific setup.
-# CONTEMPLANT_PROVER_TYPE=cpu
+# Which ZK VM(s) the spawned Contemplant should serve. Comma-separated list;
+# valid values are "sp1" and "risc0". This only kicks in when no
+# [[contemplant.provers]] entries were declared in magister.toml; if both are
+# supplied, the TOML wins. If neither is supplied, Magister fails fast at
+# startup because the spawned Contemplant would otherwise refuse to register.
+# CONTEMPLANT_VMS=sp1,risc0
+
+# Per-VM backend. Defaults to "cpu" when unset. Use "cuda" to have the spawned
+# Contemplant run with GPU acceleration (requires a Vast.ai template that
+# satisfies SP1's sm_89+ requirement when SP1 CUDA is in play).
+# CONTEMPLANT_SP1_BACKEND=cuda
+# CONTEMPLANT_RISC0_BACKEND=cuda
+
+# Opts the spawned RISC Zero worker into producing onchain Groth16 wrapped
+# proofs (default: false). Requires the released Contemplant image, which
+# ships the vendored Groth16 prover assets.
+# CONTEMPLANT_RISC0_GROTH16=true
+
+# Moongate CUDA prover endpoint for SP1 (default: none).
+# Only meaningful when CONTEMPLANT_SP1_BACKEND=cuda. If unset with CUDA,
+# sp1-sdk spins up a dockerized moongate-server inside the Vast.ai instance.
+# The URL must terminate in `/twirp/`; the Contemplant appends it
+# automatically when missing, so either form is accepted.
+# MOONGATE_ENDPOINT=http://localhost:3000/twirp/
 
 # Human-readable name for Contemplants (default: generated from names.txt).
 # CONTEMPLANT_NAME=paulos
 
 # Port for HTTP health check server (default: 9011).
 # CONTEMPLANT_HTTP_PORT=9011
-
-# Moongate CUDA prover endpoint (default: none).
-# Only used when prover_type is "cuda". If not set, Contemplant will spin up
-# a moongate-server Docker container automatically.
-# CONTEMPLANT_MOONGATE_ENDPOINT=http://localhost:3000/twirp/
 
 # Heartbeat interval in seconds (default: 30).
 # How often Contemplants tell Hierophant they are still alive.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Magister integrates with Hierophant indirectly, using Contemplants as intermedia
 1. Magister creates Contemplant instances and bootstraps them via environment variables constructed from its own configuration.
    - `MAGISTER_DROP_ENDPOINT` is constructed from Magister's `THIS_MAGISTER_ADDR` and `HTTP_PORT` configuration values, combined with the Vast offer ID (`http://magister:8555/drop/12345`).
    - `HIEROPHANT_WS_ADDRESS` is constructed from Magister's `HIEROPHANT_IP` and `HIEROPHANT_HTTP_PORT` configuration values (`ws://hierophant:9010/ws`).
+   - `CONTEMPLANT_VMS` and the matching per-VM backend variables (`CONTEMPLANT_SP1_BACKEND`, `CONTEMPLANT_RISC0_BACKEND`, etc.) are rendered from the `[[contemplant.provers]]` array in `magister.toml`, telling each spawned Contemplant which ZK VM(s) it should serve.
    These environment variables are injected into the Vast instance's `onstart` script, making them available to the Contemplant when it starts.
 2. When a Contemplant starts, it:
    - Connects to its Hierophant via WebSocket.
@@ -129,6 +130,27 @@ All configuration options can be set via environment variables:
 - `GOOD_HOSTS` - Comma-separated list of preferred host IDs
 - `GOOD_MACHINES` - Comma-separated list of preferred machine IDs
 
+**Spawned Contemplant Configuration (REQUIRED):**
+
+A Magister must be told which ZK VM(s) the Contemplants it spawns should serve. The recommended path is a `[[contemplant.provers]]` array in `magister.toml`; alternatively, the env vars below are read when no array is declared:
+
+- `CONTEMPLANT_VMS` - Comma-separated list of VMs to serve. Valid values: `sp1`, `risc0`. Required when no TOML provers are declared.
+- `CONTEMPLANT_SP1_BACKEND` - SP1 backend (`cpu` or `cuda`, default `cpu`).
+- `CONTEMPLANT_RISC0_BACKEND` - RISC Zero backend (`cpu` or `cuda`, default `cpu`).
+- `CONTEMPLANT_RISC0_GROTH16` - Whether the RISC Zero worker accepts onchain Groth16 wrap requests (`true` or `false`, default `false`).
+- `MOONGATE_ENDPOINT` - SP1 CUDA moongate URL (optional, must terminate in `/twirp/`; the Contemplant appends it automatically when missing).
+
+Declaring both `sp1` and `risc0` makes each spawned Contemplant a dual-VM worker: it advertises both VMs to Hierophant and serves either kind of proof as it becomes idle. A single Contemplant only processes one proof at a time regardless of how many VMs it advertises.
+
+**Other Spawned Contemplant Options (optional):**
+- `CONTEMPLANT_NAME` - Human-readable name (default: random from `names.txt`)
+- `CONTEMPLANT_HTTP_PORT` - Health check port on the Vast.ai instance (default: 9011)
+- `CONTEMPLANT_HEARTBEAT_INTERVAL_SECONDS` - How often the Contemplant pings Hierophant (default: 30)
+- `CONTEMPLANT_MAX_PROOFS_STORED` - Finished proofs to keep in memory (default: 2)
+- `CONTEMPLANT_MOONGATE_LOG_PATH` - Where the Contemplant tails moongate logs from (default: `./moongate.log`)
+- `CONTEMPLANT_WATCHER_POLLING_INTERVAL_MS` - Moongate log polling interval (default: 2000)
+- `CONTEMPLANT_SSH_AUTHORIZED_KEYS` - Newline-separated SSH public keys for debugging access on port 2222
+
 ### Example: Environment Variable Only Configuration
 
 ```bash
@@ -141,6 +163,13 @@ export NUMBER_INSTANCES="5"
 export VAST_QUERY_GPU_NAME="RTX 4090"
 export VAST_QUERY_GPU_RAM="24"
 export VAST_QUERY_COST_PER_HOUR="0.53"
+
+# Tell each spawned Contemplant to serve both SP1 and RISC Zero on the GPU,
+# and to accept onchain Groth16 wrap requests for RISC Zero.
+export CONTEMPLANT_VMS="sp1,risc0"
+export CONTEMPLANT_SP1_BACKEND="cuda"
+export CONTEMPLANT_RISC0_BACKEND="cuda"
+export CONTEMPLANT_RISC0_GROTH16="true"
 # ... other configuration ...
 
 RUST_LOG=info cargo run --release

--- a/magister.example.toml
+++ b/magister.example.toml
@@ -76,7 +76,7 @@ gpu_name = "RTX 4090"
 reliability = 0.99
 
 # REQUIRED: Minimum CUDA version required.
-min_cuda_version = 12.8
+min_cuda_version = 12.9
 
 # REQUIRED: Minimum GPU RAM in GB.
 gpu_ram = 24
@@ -92,25 +92,19 @@ duration = 192679
 # Instances costing more than this will be filtered out.
 cost_per_hour = 0.60
 
-# Contemplant configuration controls settings for Contemplants spawned by this Magister.
-# These settings are passed as environment variables to Contemplants on Vast.ai.
-# Note: MAGISTER_DROP_ENDPOINT and HIEROPHANT_WS_ADDRESS are managed automatically.
+# Contemplant configuration controls settings for Contemplants spawned by this
+# Magister. These settings are rendered into environment variables on the
+# Vast.ai instance's onstart command, and the Contemplant binary's env-var
+# fallback expands them back into its internal config. Note that
+# MAGISTER_DROP_ENDPOINT and HIEROPHANT_WS_ADDRESS are managed automatically
+# and do not appear here.
 [contemplant]
-
-# OPTIONAL: Prover type - "cpu" or "cuda" (default: "cpu").
-# CPU proving is slower but doesn't require GPU-specific setup.
-# prover_type = "cpu"
 
 # OPTIONAL: Human-readable name for Contemplants (default: generated from names.txt).
 # contemplant_name = "paulos"
 
 # OPTIONAL: Port for HTTP health check server (default: 9011).
 # http_port = 9011
-
-# OPTIONAL: Moongate CUDA prover endpoint (default: none).
-# Only used when prover_type is "cuda". If not set, Contemplant will spin up
-# a moongate-server Docker container automatically.
-# moongate_endpoint = "http://localhost:3000/twirp/"
 
 # OPTIONAL: Heartbeat interval in seconds (default: 30).
 # How often Contemplants tell Hierophant they are still alive.
@@ -133,3 +127,36 @@ cost_per_hour = 0.60
 # ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAbc123... user@host
 # ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC... another@host
 # """
+
+# REQUIRED: Declare which ZK VM(s) each spawned Contemplant should serve and
+# with which backend. At least one [[contemplant.provers]] entry is required.
+#
+# Fields:
+#   vm                = "sp1" | "risc0"        (required)
+#   backend           = "cpu" | "cuda"          (default: "cpu")
+#   moongate_endpoint = "http://host:3000/twirp/"  (SP1 CUDA only; optional)
+#   groth16_enabled   = true | false            (RISC Zero only; default: false)
+#
+# A single entry yields a homogeneous pool. Declaring both `sp1` and `risc0`
+# produces a Contemplant that advertises both VMs to Hierophant and serves
+# either kind of proof as it becomes idle (one proof at a time per worker).
+#
+# Examples below show a dual-VM CUDA pool. Comment them out and pick whichever
+# shape fits your Vast.ai pool.
+
+[[contemplant.provers]]
+vm = "sp1"
+backend = "cuda"
+
+# Omit moongate_endpoint to have sp1-sdk spin up a dockerized moongate-server
+# inside the Vast.ai instance. Supply it to point at an external moongate.
+moongate_endpoint = "http://localhost:3000/twirp/"
+
+[[contemplant.provers]]
+vm = "risc0"
+backend = "cuda"
+
+# Set groth16_enabled = true to opt this worker into producing onchain
+# Groth16 wrapped proofs. Requires the Contemplant image to ship the
+# vendored Groth16 prover assets (the released image does).
+groth16_enabled = true

--- a/src/config.rs
+++ b/src/config.rs
@@ -60,20 +60,95 @@ fn default_http_port() -> u16 {
     8555
 }
 
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ProverBackend {
+    Cpu,
+    Cuda,
+}
+
+impl ProverBackend {
+    fn as_str(&self) -> &'static str {
+        match self {
+            ProverBackend::Cpu => "cpu",
+            ProverBackend::Cuda => "cuda",
+        }
+    }
+}
+
+impl std::str::FromStr for ProverBackend {
+    type Err = anyhow::Error;
+    fn from_str(s: &str) -> Result<Self> {
+        match s.to_lowercase().as_str() {
+            "cpu" => Ok(ProverBackend::Cpu),
+            "cuda" => Ok(ProverBackend::Cuda),
+            _ => anyhow::bail!("Invalid prover backend: '{}'. Must be 'cpu' or 'cuda'", s),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum VmChoice {
+    Sp1,
+    Risc0,
+}
+
+impl VmChoice {
+    fn as_str(&self) -> &'static str {
+        match self {
+            VmChoice::Sp1 => "sp1",
+            VmChoice::Risc0 => "risc0",
+        }
+    }
+}
+
+/// One entry per VM the spawned Contemplant should serve. Mirrors
+/// `ProverConfig` in hierophant's `src/contemplant/src/config.rs`; values are
+/// rendered as a comma-separated `CONTEMPLANT_VMS` plus per-VM backend env
+/// vars in `to_env_exports`, which the Contemplant's env-var fallback in
+/// `Config::load` then expands back into a `provers` array. A single entry
+/// is fine for a homogeneous pool; declaring both `sp1` and `risc0` lets one
+/// Contemplant serve both (it processes one proof at a time, but Hierophant
+/// can hand it either kind of work).
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ProverConfig {
+    pub vm: VmChoice,
+    #[serde(default = "default_backend")]
+    pub backend: ProverBackend,
+    /// Only meaningful for `vm = "sp1"` with `backend = "cuda"`. URL must
+    /// terminate in `/twirp/`; the Contemplant appends it automatically when
+    /// missing, so either form is accepted. Omit to have sp1-sdk spin up a
+    /// dockerized moongate-server inside the Vast.ai instance.
+    #[serde(default)]
+    pub moongate_endpoint: Option<String>,
+    /// Only meaningful for `vm = "risc0"`. Opts the worker into producing
+    /// Groth16 wrapped proofs (the onchain-verifiable flavor). Requires the
+    /// Contemplant image to ship the vendored Groth16 prover assets, which
+    /// the released Hierophant Contemplant image does.
+    #[serde(default)]
+    pub groth16_enabled: bool,
+}
+
+fn default_backend() -> ProverBackend {
+    ProverBackend::Cpu
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ContemplantConfig {
-    /// Prover type: "cpu" or "cuda" (default: "cpu")
-    #[serde(default = "default_prover_type")]
-    pub prover_type: String,
+    /// Which VMs the spawned Contemplant should serve, and how. At least one
+    /// entry is required for the Contemplant to start up successfully on the
+    /// Vast.ai instance. A single entry yields a homogeneous pool; declaring
+    /// both `sp1` and `risc0` produces a Contemplant that advertises both VMs
+    /// to Hierophant and serves proofs of either kind as it becomes idle.
+    #[serde(default)]
+    pub provers: Vec<ProverConfig>,
     /// Human-readable name for Contemplants (default: generated from names.txt)
     #[serde(default)]
     pub contemplant_name: Option<String>,
     /// Port for HTTP health check server (default: 9011)
     #[serde(default = "default_contemplant_http_port")]
     pub http_port: u16,
-    /// Moongate CUDA prover endpoint (default: none)
-    #[serde(default)]
-    pub moongate_endpoint: Option<String>,
     /// Heartbeat interval in seconds (default: 30)
     #[serde(default = "default_heartbeat_interval_seconds")]
     pub heartbeat_interval_seconds: u64,
@@ -90,10 +165,6 @@ pub struct ContemplantConfig {
     /// Format: newline-separated SSH public keys
     #[serde(default)]
     pub ssh_authorized_keys: Option<String>,
-}
-
-fn default_prover_type() -> String {
-    "cpu".to_string()
 }
 
 fn default_contemplant_http_port() -> u16 {
@@ -119,10 +190,9 @@ fn default_watcher_polling_interval_ms() -> u64 {
 impl Default for ContemplantConfig {
     fn default() -> Self {
         Self {
-            prover_type: default_prover_type(),
+            provers: Vec::new(),
             contemplant_name: None,
             http_port: default_contemplant_http_port(),
-            moongate_endpoint: None,
             heartbeat_interval_seconds: default_heartbeat_interval_seconds(),
             max_proofs_stored: default_max_proofs_stored(),
             moongate_log_path: default_moongate_log_path(),
@@ -134,12 +204,54 @@ impl Default for ContemplantConfig {
 
 impl ContemplantConfig {
     /// Generate environment variable exports for the onstart command.
-    /// These will be passed to Contemplants spawned on Vast.ai.
+    /// These will be passed to Contemplants spawned on Vast.ai. The
+    /// Contemplant's env-var fallback (when no contemplant.toml is mounted)
+    /// reads CONTEMPLANT_VMS, CONTEMPLANT_SP1_BACKEND, CONTEMPLANT_RISC0_BACKEND,
+    /// CONTEMPLANT_RISC0_GROTH16, and MOONGATE_ENDPOINT to reconstruct its
+    /// `provers` array. See hierophant's src/contemplant/src/config.rs.
     pub fn to_env_exports(&self) -> String {
         let mut exports = Vec::new();
 
-        // Always export prover type
-        exports.push(format!("export PROVER_TYPE=\\\"{}\\\"", self.prover_type));
+        // Per-VM declarations. CONTEMPLANT_VMS lists every VM this worker
+        // serves; per-VM backend env vars carry the cpu|cuda choice and (for
+        // SP1) any moongate endpoint or (for RISC Zero) the groth16 toggle.
+        if !self.provers.is_empty() {
+            let vms = self
+                .provers
+                .iter()
+                .map(|p| p.vm.as_str())
+                .collect::<Vec<_>>()
+                .join(",");
+            exports.push(format!("export CONTEMPLANT_VMS=\\\"{}\\\"", vms));
+
+            for prover in &self.provers {
+                match prover.vm {
+                    VmChoice::Sp1 => {
+                        exports.push(format!(
+                            "export CONTEMPLANT_SP1_BACKEND=\\\"{}\\\"",
+                            prover.backend.as_str()
+                        ));
+                        if let Some(ref endpoint) = prover.moongate_endpoint {
+                            exports.push(format!(
+                                "export MOONGATE_ENDPOINT=\\\"{}\\\"",
+                                endpoint
+                            ));
+                        }
+                    }
+                    VmChoice::Risc0 => {
+                        exports.push(format!(
+                            "export CONTEMPLANT_RISC0_BACKEND=\\\"{}\\\"",
+                            prover.backend.as_str()
+                        ));
+                        if prover.groth16_enabled {
+                            exports.push(
+                                "export CONTEMPLANT_RISC0_GROTH16=\\\"true\\\"".to_string(),
+                            );
+                        }
+                    }
+                }
+            }
+        }
 
         // Optional exports
         if let Some(ref name) = self.contemplant_name {
@@ -148,10 +260,6 @@ impl ContemplantConfig {
 
         // Always export http_port
         exports.push(format!("export HTTP_PORT=\\\"{}\\\"", self.http_port));
-
-        if let Some(ref endpoint) = self.moongate_endpoint {
-            exports.push(format!("export MOONGATE_ENDPOINT=\\\"{}\\\"", endpoint));
-        }
 
         exports.push(format!("export HEARTBEAT_INTERVAL_SECONDS=\\\"{}\\\"", self.heartbeat_interval_seconds));
         exports.push(format!("export MAX_PROOFS_STORED=\\\"{}\\\"", self.max_proofs_stored));
@@ -335,18 +443,18 @@ impl Config {
             config.good_machines = Some(machines.context("GOOD_MACHINES must be comma-separated u64 values")?);
         }
 
-        // ContemplantConfig overrides
-        if let Ok(val) = env::var("CONTEMPLANT_PROVER_TYPE") {
-            config.contemplant.prover_type = val;
-        }
+        // ContemplantConfig overrides. The `provers` array can be supplied
+        // either by listing it in magister.toml under [[contemplant.provers]]
+        // (the recommended path) or by setting CONTEMPLANT_VMS plus the
+        // matching per-VM env vars below. The env-var path is convenient for
+        // CI / docker-compose; it's only consulted when the TOML didn't
+        // declare any provers, mirroring the same precedence rule the
+        // Contemplant itself follows.
         if let Ok(val) = env::var("CONTEMPLANT_NAME") {
             config.contemplant.contemplant_name = Some(val);
         }
         if let Ok(val) = env::var("CONTEMPLANT_HTTP_PORT") {
             config.contemplant.http_port = val.parse().context("CONTEMPLANT_HTTP_PORT must be a valid u16")?;
-        }
-        if let Ok(val) = env::var("CONTEMPLANT_MOONGATE_ENDPOINT") {
-            config.contemplant.moongate_endpoint = Some(val);
         }
         if let Ok(val) = env::var("CONTEMPLANT_HEARTBEAT_INTERVAL_SECONDS") {
             config.contemplant.heartbeat_interval_seconds = val.parse().context("CONTEMPLANT_HEARTBEAT_INTERVAL_SECONDS must be a valid u64")?;
@@ -362,6 +470,53 @@ impl Config {
         }
         if let Ok(val) = env::var("CONTEMPLANT_SSH_AUTHORIZED_KEYS") {
             config.contemplant.ssh_authorized_keys = Some(val);
+        }
+        if config.contemplant.provers.is_empty() {
+            if let Ok(vms) = env::var("CONTEMPLANT_VMS") {
+                use std::str::FromStr;
+                for token in vms.split(',').map(str::trim).filter(|t| !t.is_empty()) {
+                    match token.to_lowercase().as_str() {
+                        "sp1" => {
+                            let backend = env::var("CONTEMPLANT_SP1_BACKEND")
+                                .ok()
+                                .map(|s| ProverBackend::from_str(&s))
+                                .transpose()
+                                .context("CONTEMPLANT_SP1_BACKEND must be 'cpu' or 'cuda'")?
+                                .unwrap_or(ProverBackend::Cpu);
+                            let moongate_endpoint = env::var("MOONGATE_ENDPOINT").ok();
+                            config.contemplant.provers.push(ProverConfig {
+                                vm: VmChoice::Sp1,
+                                backend,
+                                moongate_endpoint,
+                                groth16_enabled: false,
+                            });
+                        }
+                        "risc0" => {
+                            let backend = env::var("CONTEMPLANT_RISC0_BACKEND")
+                                .ok()
+                                .map(|s| ProverBackend::from_str(&s))
+                                .transpose()
+                                .context("CONTEMPLANT_RISC0_BACKEND must be 'cpu' or 'cuda'")?
+                                .unwrap_or(ProverBackend::Cpu);
+                            let groth16_enabled = env::var("CONTEMPLANT_RISC0_GROTH16")
+                                .ok()
+                                .map(|s| s.parse::<bool>())
+                                .transpose()
+                                .context("CONTEMPLANT_RISC0_GROTH16 must be 'true' or 'false'")?
+                                .unwrap_or(false);
+                            config.contemplant.provers.push(ProverConfig {
+                                vm: VmChoice::Risc0,
+                                backend,
+                                moongate_endpoint: None,
+                                groth16_enabled,
+                            });
+                        }
+                        other => anyhow::bail!(
+                            "Unknown VM '{other}' in CONTEMPLANT_VMS (expected sp1, risc0)"
+                        ),
+                    }
+                }
+            }
         }
 
         // Validate required fields
@@ -394,6 +549,36 @@ impl Config {
             anyhow::bail!(
                 "number_instances is required. Provide it via config file or NUMBER_INSTANCES environment variable."
             );
+        }
+        // Match the Contemplant's own validation. Without at least one prover
+        // entry the spawned Contemplant will refuse to register with
+        // Hierophant, so fail fast here rather than after a Vast.ai instance
+        // boots and burns its first 30 minutes of rent before we notice.
+        if config.contemplant.provers.is_empty() {
+            anyhow::bail!(
+                "At least one [[contemplant.provers]] entry is required. \
+                 Declare which VM(s) the spawned Contemplant should serve, \
+                 either in magister.toml or via CONTEMPLANT_VMS=sp1,risc0 \
+                 (with CONTEMPLANT_SP1_BACKEND, CONTEMPLANT_RISC0_BACKEND, \
+                 etc. as needed)."
+            );
+        }
+        // Sanity-check that fields are paired with their supporting VM.
+        for prover in &config.contemplant.provers {
+            if prover.moongate_endpoint.is_some() && !matches!(prover.vm, VmChoice::Sp1) {
+                anyhow::bail!(
+                    "moongate_endpoint is only meaningful for vm = \"sp1\"; \
+                     saw it on {:?}.",
+                    prover.vm
+                );
+            }
+            if prover.groth16_enabled && !matches!(prover.vm, VmChoice::Risc0) {
+                anyhow::bail!(
+                    "groth16_enabled is only meaningful for vm = \"risc0\"; \
+                     saw it on {:?}.",
+                    prover.vm
+                );
+            }
         }
 
         Ok(config)


### PR DESCRIPTION
## Description
In line with our improvements to Hierophant, the Magister can now manage Contemplants that are capable of using our new RISC Zero support.

## Breaking Changes
The `magister.toml` configuration format has changed; this will only support newer Contemplants which are aware of our post-RISC Zero configuration details.

## Features
Magisters can now spawn Contemplants that are capable of generating both SP1 and RISC Zero proofs.